### PR TITLE
2014 updates 0.0.4

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -30,12 +30,15 @@ div.menu,
   }
 
 .entry-content img.size-full {
-  border: 1px solid #333;
-  padding: 5px;
+  border: none;
+  padding: none;
   -moz-box-shadow: 2px 2px 10px #333;
   -webkit-box-shadow: 2px 2px 10px #333;
 }
-
+img {
+  max-width: 100%;
+  height: auto;
+}
 iframe, object, embed{
   max-width: 100%;
 }

--- a/css/style.css
+++ b/css/style.css
@@ -35,10 +35,19 @@ div.menu,
   -moz-box-shadow: 2px 2px 10px #333;
   -webkit-box-shadow: 2px 2px 10px #333;
 }
+
 img {
   max-width: 100%;
   height: auto;
 }
+
+#content img {
+  border: none;
+  padding: none;
+  -moz-box-shadow: none;
+  -webkit-box-shadow: none;
+}
+
 iframe, object, embed{
   max-width: 100%;
 }

--- a/readme.txt
+++ b/readme.txt
@@ -3,8 +3,8 @@ Contributors: toddhalfpenny
 Donate link: http://gingerbreaddesign.co.uk/wordpress/plugins/plugins.php
 Tags: css, twentyten, responsive
 Requires at least: 2.8
-Tested up to: 3.1
-Stable tag: 0.0.3
+Tested up to: 5.2.2
+Stable tag: 0.0.4
 
 Makes your TwentyTen themed site have a responsive and fluid layout
 
@@ -40,6 +40,14 @@ The WordPress.org theme repository doesn't support the submission of child theme
 
 
 == Changelog ==
+
+= 0.0.4 = 
+
+Tweaks from https://www.mikematera.com/make-your-wordpress-twenty-ten-theme-responsive/ :
+
+ * Adjust header image to screen size
+
+ * Don't add shadows and borders to images
 
 = 0.0.3 = 
 

--- a/responsive-twentyten.php
+++ b/responsive-twentyten.php
@@ -22,7 +22,7 @@ Plugin Name: Responsive TwentyTen
 Plugin URI: http://gingerbreaddesign.co.uk/wordpress/responsive-twentyten/
 Description: Makes your TwentyTen themed site have a responsive and fluid layout. Making it ideal for for viewing across a whole range of devices and screen sizes (i.e iPhones, Android, iPads)
 Author: Todd Halfpenny
-Version: 0.0.3
+Version: 0.0.4
 Author URI: http://gingerbreaddesign.co.uk/todd
 */
 


### PR DESCRIPTION
These are the 2014 CSS updates [proposed by Mike Matera](https://www.mikematera.com/make-your-wordpress-twenty-ten-theme-responsive/) and [summarized by dccharron](https://wordpress.org/support/topic/still-works-after-all-these-years/). I merely forked your repo, added the changes, then updated to a 0.0.4 release.

Fixes: #1